### PR TITLE
the context argument is now optional so we don't have to pass null

### DIFF
--- a/test/commands/editor/spring/setSpringBootVersionEditorTest.ts
+++ b/test/commands/editor/spring/setSpringBootVersionEditorTest.ts
@@ -11,28 +11,24 @@ describe("setSpringBootVersionEditor", () => {
     it("doesn't edit empty project", done => {
         const p = new InMemoryProject();
         setSpringBootVersionEditor("1.3.1")(p)
-            .then(r => {
-                done();
-            }).catch(done);
+            .then(() => done(), done);
     });
 
     it("actually edits Spring Boot project in memory", done => {
         const p = InMemoryProject.of({ path: "pom.xml", content: springBootPom("1.3.0") });
-        setSpringBootVersionEditor("1.3.1")(p, null)
+        setSpringBootVersionEditor("1.3.1")(p)
             .then(r => {
                 assert(p.findFileSync("pom.xml").getContentSync().includes("1.3.1"));
-                done();
-            }).catch(done);
+            }).then(() => done(), done);
     });
 
     it("actually edits Spring Boot project on disk", done => {
         const p = tempProject();
         p.addFileSync("pom.xml", springBootPom("1.3.0"));
-        setSpringBootVersionEditor("1.3.1")(p, null)
+        setSpringBootVersionEditor("1.3.1")(p)
             .then(r => {
                 assert(p.findFileSync("pom.xml").getContentSync().includes("1.3.1"));
-                done();
-            }).catch(done);
+            }).then(() => done(), done);
     });
 
 });


### PR DESCRIPTION
I want to link to this test from the docs so have a tiny cleanup.